### PR TITLE
Returned old methods for set uniform

### DIFF
--- a/src/client/graphics/Shader.cpp
+++ b/src/client/graphics/Shader.cpp
@@ -12,6 +12,21 @@ unsigned int Shader::getId() const noexcept
     return m_id;
 }
 
+void Shader::setVector2(const std::string &name, const glm::vec2 &data)
+{
+    glUniform2f(glGetUniformLocation(m_id, name.c_str()), data.x, data.y);
+}
+
+void Shader::setVector3(const std::string &name, const glm::vec3 &data)
+{
+    glUniform3f(glGetUniformLocation(m_id, name.c_str()), data.x, data.y, data.z);
+}
+
+void Shader::setMatrix4(const std::string &name, const glm::mat4 &data)
+{
+    glUniformMatrix4fv(glGetUniformLocation(m_id, name.c_str()), 1, false, glm::value_ptr(data));
+}
+
 void Shader::destroy()
 {
     glDeleteProgram(m_id);

--- a/src/client/graphics/Shader.cpp
+++ b/src/client/graphics/Shader.cpp
@@ -1,4 +1,6 @@
 #include "Shader.h"
+#include <fstream>
+#include <sstream>
 
 Shader::Shader(unsigned int m_id) : m_id(m_id) { }
 

--- a/src/client/graphics/Shader.h
+++ b/src/client/graphics/Shader.h
@@ -8,10 +8,7 @@
 #include "IGLObject.h"
 
 #include <string>
-#include <fstream>
-#include <sstream>
 #include <iostream>
-#include <functional>
 
 class Shader : public IGLObject
 {

--- a/src/client/graphics/SpriteBatch.cpp
+++ b/src/client/graphics/SpriteBatch.cpp
@@ -90,9 +90,9 @@ void SpriteBatch::end()
 
     int *ids = new int[m_texturesSize];
     std::iota(ids, ids + m_texturesSize, 0);
-    m_shader.setUniform("textures", m_texturesSize, ids);
+    m_shader.setArray("textures", m_texturesSize, ids);
 
-    m_shader.setUniform("model", glm::mat4(1));
+    m_shader.setMatrix4("model", glm::mat4(1));
 
     for (int i = 0; i < m_texturesSize; i++)
     {
@@ -224,13 +224,13 @@ void SpriteBatch::draw(const Sprite &sprite, int layer, int order)
 void SpriteBatch::setProjectionMatrix(glm::mat4 projMat)
 {
     m_shader.use();
-    m_shader.setUniform("projection", projMat);
+    m_shader.setMatrix4("projection", projMat);
 }
 
 void SpriteBatch::setViewMatrix(glm::mat4 viewMat)
 {
     m_shader.use();
-    m_shader.setUniform("view", viewMat);
+    m_shader.setMatrix4("view", viewMat);
 }
 
 void SpriteBatch::destroy()


### PR DESCRIPTION
Since the setUniform() method gives out compilation errors in the current situation, it was decided to revert to the old way.
P.S. templates is very confusing)