### PR TITLE
Introduce precompiled headers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,7 @@ file(GLOB_RECURSE HEADERS "src/*.h" "src/*.hpp")
 
 add_executable(${PROJECT_NAME} ${SOURCES} ${HEADERS})
 target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_17)
+target_precompile_headers(${PROJECT_NAME} PRIVATE src/pch.h)
 #if(NOT WIN32)
 #    # it doesn't work on Windows with mingw
 #    target_compile_options(${PROJECT_NAME} PRIVATE -fno-omit-frame-pointer -fsanitize=address)

--- a/src/Game.cpp
+++ b/src/Game.cpp
@@ -1,3 +1,4 @@
+#include "pch.h"
 #include "Game.h"
 
 #include "systems/script/ScriptSystem.h"

--- a/src/client/Engine.cpp
+++ b/src/client/Engine.cpp
@@ -1,3 +1,4 @@
+#include "../pch.h"
 #include "Engine.h"
 
 #include "window/GlfwWindow.h"

--- a/src/client/audio/AudioDevice.cpp
+++ b/src/client/audio/AudioDevice.cpp
@@ -1,3 +1,4 @@
+#include "../../pch.h"
 #include "AudioDevice.h"
 
 #include <iostream>

--- a/src/client/audio/AudioSource.cpp
+++ b/src/client/audio/AudioSource.cpp
@@ -1,3 +1,4 @@
+#include "../../pch.h"
 #include "AudioSource.h"
 
 AudioSource::AudioSource(IAudioClip &audioClip)

--- a/src/client/audio/CachedAudioClip.cpp
+++ b/src/client/audio/CachedAudioClip.cpp
@@ -1,3 +1,4 @@
+#include "../../pch.h"
 #include "CachedAudioClip.h"
 
 #include "AudioDevice.h"

--- a/src/client/audio/StreamAudioClip.cpp
+++ b/src/client/audio/StreamAudioClip.cpp
@@ -1,3 +1,4 @@
+#include "../../pch.h"
 #include "StreamAudioClip.h"
 #include "AudioDevice.h"
 

--- a/src/client/graphics/Bitmap.cpp
+++ b/src/client/graphics/Bitmap.cpp
@@ -1,3 +1,4 @@
+#include "../../pch.h"
 #include "Bitmap.h"
 #include <cassert>
 

--- a/src/client/graphics/Buffer.cpp
+++ b/src/client/graphics/Buffer.cpp
@@ -1,3 +1,4 @@
+#include "../../pch.h"
 #include "Buffer.h"
 
 Buffer::Buffer(unsigned int target) : m_target(target)

--- a/src/client/graphics/Font.cpp
+++ b/src/client/graphics/Font.cpp
@@ -1,3 +1,4 @@
+#include "../../pch.h"
 #include "Font.h"
 
 #include <ft2build.h>

--- a/src/client/graphics/Quad.cpp
+++ b/src/client/graphics/Quad.cpp
@@ -1,3 +1,4 @@
+#include "../../pch.h"
 #include "Quad.h"
 
 Quad::Quad()

--- a/src/client/graphics/Shader.cpp
+++ b/src/client/graphics/Shader.cpp
@@ -1,3 +1,4 @@
+#include "../../pch.h"
 #include "Shader.h"
 #include <fstream>
 #include <sstream>

--- a/src/client/graphics/Sprite.cpp
+++ b/src/client/graphics/Sprite.cpp
@@ -1,3 +1,4 @@
+#include "../../pch.h"
 #include "Sprite.h"
 
 Sprite::Sprite()

--- a/src/client/graphics/SpriteBatch.cpp
+++ b/src/client/graphics/SpriteBatch.cpp
@@ -1,3 +1,4 @@
+#include "../../pch.h"
 #include "SpriteBatch.h"
 
 #include "Graphics.h"

--- a/src/client/graphics/Text.cpp
+++ b/src/client/graphics/Text.cpp
@@ -1,3 +1,4 @@
+#include "../../pch.h"
 #include "Text.h"
 
 Text::Text(Font &font, std::string text)

--- a/src/client/graphics/Texture.cpp
+++ b/src/client/graphics/Texture.cpp
@@ -1,3 +1,4 @@
+#include "../../pch.h"
 #include "Texture.h"
 
 #include <iostream>

--- a/src/client/graphics/VertexArray.cpp
+++ b/src/client/graphics/VertexArray.cpp
@@ -1,3 +1,4 @@
+#include "../../pch.h"
 #include "VertexArray.h"
 
 #include "Graphics.h"

--- a/src/client/input/GlfwKeyMapper.cpp
+++ b/src/client/input/GlfwKeyMapper.cpp
@@ -1,3 +1,4 @@
+#include "../../pch.h"
 #include "GlfwKeyMapper.h"
 
 int GlfwKeyMapper::map(Key key)

--- a/src/client/input/KeyMappingConfig.cpp
+++ b/src/client/input/KeyMappingConfig.cpp
@@ -1,3 +1,4 @@
+#include "../../pch.h"
 #include "KeyMappingConfig.h"
 
 KeyMappingConfig::KeyMappingConfig(std::string configPath)

--- a/src/client/input/StringKeyMapper.cpp
+++ b/src/client/input/StringKeyMapper.cpp
@@ -1,3 +1,4 @@
+#include "../../pch.h"
 #include "StringKeyMapper.h"
 
 #include <algorithm>

--- a/src/client/window/GlfwWindow.cpp
+++ b/src/client/window/GlfwWindow.cpp
@@ -1,3 +1,4 @@
+#include "../../pch.h"
 #include "GlfwWindow.h"
 
 #include <iostream>

--- a/src/components/audio/AudioSourceComponent.cpp
+++ b/src/components/audio/AudioSourceComponent.cpp
@@ -1,3 +1,4 @@
+#include "../../pch.h"
 #include "AudioSourceComponent.h"
 
 AudioSourceComponent::AudioSourceComponent(IAudioClip &audioClip)

--- a/src/components/render/CameraComponent.cpp
+++ b/src/components/render/CameraComponent.cpp
@@ -1,3 +1,4 @@
+#include "../../pch.h"
 #include "glm/ext/matrix_clip_space.hpp"
 #include "CameraComponent.h"
 

--- a/src/components/render/SpriteRendererComponent.cpp
+++ b/src/components/render/SpriteRendererComponent.cpp
@@ -1,3 +1,4 @@
+#include "../../pch.h"
 #include "SpriteRendererComponent.h"
 
 SpriteRendererComponent::SpriteRendererComponent(Texture texture)

--- a/src/components/render/TextRendererComponent.cpp
+++ b/src/components/render/TextRendererComponent.cpp
@@ -1,3 +1,4 @@
+#include "../../pch.h"
 #include "TextRendererComponent.h"
 
 TextRendererComponent::TextRendererComponent(Font *font, std::string text)

--- a/src/components/render/ui/ButtonConmponent.cpp
+++ b/src/components/render/ui/ButtonConmponent.cpp
@@ -1,3 +1,4 @@
+#include "../../../pch.h"
 #include <utility>
 
 #include "ButtonComponent.h"

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,3 +1,4 @@
+#include "pch.h"
 #include "utils/GameTimer.h"
 #include "client/Engine.h"
 #include "Game.h"

--- a/src/pch.h
+++ b/src/pch.h
@@ -1,0 +1,26 @@
+#ifndef RPG_PCH_H
+#define RPG_PCH_H
+
+// std
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <fstream>
+#include <functional>
+#include <iostream>
+#include <map>
+#include <mutex>
+#include <set>
+#include <sstream>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+// 3rd party
+#include <glm/glm.hpp>
+#include <glm/gtc/matrix_transform.hpp>
+#include <glm/gtc/type_ptr.hpp>
+#include <miniaudio.h>
+#include <yaml-cpp/yaml.h>
+
+#endif // RPG_PCH_H

--- a/src/scene/Entity.cpp
+++ b/src/scene/Entity.cpp
@@ -1,3 +1,4 @@
+#include "../pch.h"
 #include "Entity.h"
 
 Entity::Entity(entt::entity entity, entt::registry *registry)

--- a/src/scene/Scene.cpp
+++ b/src/scene/Scene.cpp
@@ -1,3 +1,4 @@
+#include "../pch.h"
 #include "Scene.h"
 
 #include "Entity.h"

--- a/src/systems/audio/AudioSystem.cpp
+++ b/src/systems/audio/AudioSystem.cpp
@@ -1,3 +1,4 @@
+#include "../../pch.h"
 #include "AudioSystem.h"
 
 #include <iostream>

--- a/src/systems/physics/PhysicsSystem.cpp
+++ b/src/systems/physics/PhysicsSystem.cpp
@@ -1,3 +1,4 @@
+#include "../../pch.h"
 #include "PhysicsSystem.h"
 
 #include "../../components/physics/RigidbodyComponent.h"

--- a/src/systems/player/PlayerSystem.cpp
+++ b/src/systems/player/PlayerSystem.cpp
@@ -1,3 +1,4 @@
+#include "../../pch.h"
 #include "PlayerSystem.h"
 
 #include "../../client/Engine.h"

--- a/src/systems/render/PointLightRenderSystem.cpp
+++ b/src/systems/render/PointLightRenderSystem.cpp
@@ -1,3 +1,4 @@
+#include "../../pch.h"
 #include "PointLightRenderSystem.h"
 
 #include "../../components/render/PoinLightComponent.h"

--- a/src/systems/render/RenderSystem.cpp
+++ b/src/systems/render/RenderSystem.cpp
@@ -1,3 +1,4 @@
+#include "../../pch.h"
 #include "RenderSystem.h"
 
 #include "glm/ext/matrix_transform.hpp"

--- a/src/systems/render/SpriteRenderSystem.cpp
+++ b/src/systems/render/SpriteRenderSystem.cpp
@@ -1,3 +1,4 @@
+#include "../../pch.h"
 #include "SpriteRenderSystem.h"
 
 #include "../../components/render/SpriteRendererComponent.h"

--- a/src/systems/render/TextRenderSystem.cpp
+++ b/src/systems/render/TextRenderSystem.cpp
@@ -1,3 +1,4 @@
+#include "../../pch.h"
 #include "TextRenderSystem.h"
 
 #include "../../components/render/TextRendererComponent.h"

--- a/src/systems/render/WorldMapRenderSystem.cpp
+++ b/src/systems/render/WorldMapRenderSystem.cpp
@@ -1,3 +1,4 @@
+#include "../../pch.h"
 #include "WorldMapRenderSystem.h"
 
 #include "../../components/world/WorldMapComponent.h"

--- a/src/systems/render/ui/ButtonRenderSystem.cpp
+++ b/src/systems/render/ui/ButtonRenderSystem.cpp
@@ -1,3 +1,4 @@
+#include "../../../pch.h"
 #include "ButtonRenderSystem.h"
 
 #include "../../../components/render/ui/ButtonComponent.h"

--- a/src/systems/render/ui/InventoryRenderSystem.cpp
+++ b/src/systems/render/ui/InventoryRenderSystem.cpp
@@ -1,3 +1,4 @@
+#include "../../../pch.h"
 #include "InventoryRenderSystem.h"
 
 #include "../../../components/render/CameraComponent.h"

--- a/src/systems/render/ui/UIRenderSystem.cpp
+++ b/src/systems/render/ui/UIRenderSystem.cpp
@@ -1,3 +1,4 @@
+#include "../../../pch.h"
 #include "UIRenderSystem.h"
 
 #include "glm/vec2.hpp"

--- a/src/systems/script/ScriptSystem.cpp
+++ b/src/systems/script/ScriptSystem.cpp
@@ -1,3 +1,4 @@
+#include "../../pch.h"
 #include "ScriptSystem.h"
 
 #include "../../components/script/NativeScriptComponent.h"

--- a/src/utils/Hierarchy.cpp
+++ b/src/utils/Hierarchy.cpp
@@ -1,3 +1,4 @@
+#include "../pch.h"
 #include "Hierarchy.h"
 
 #include "../components/basic/HierarchyComponent.h"

--- a/src/utils/OpenSimplexNoise.cpp
+++ b/src/utils/OpenSimplexNoise.cpp
@@ -1,3 +1,4 @@
+#include "../pch.h"
 #include "OpenSimplexNoise.h"
 #include <cmath>
 #include <ctime>


### PR DESCRIPTION
TrueRPG compilation on my machine with llvmlinux toolchain with 10 threads was taking 12 seconds including the time compiling 3rd party libraries.
After I added precompiled headers it's taking 8 seconds.
We should take including pch.h in every .cpp file as a rule of thumb. It speeds up build (which also help with CI).

I didn't use ccache (for obvious reasons).