### PR TITLE
Introduce lint workflow: it will check that every file includes pch.h

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,23 @@
+name: Lint
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  pch-included-everywhere:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Install Packages
+        run: |
+          sudo apt-get update
+          sudo apt-get install zsh
+
+      - name: Lint
+        run: zsh scripts/pch-included-everywhere.zsh

--- a/scripts/find-files-without-include.zsh
+++ b/scripts/find-files-without-include.zsh
@@ -1,0 +1,19 @@
+#!/usr/bin/env zsh
+directoryToSearch="$1"
+includeFile="$2"
+
+while read -r line
+do
+	file="$line"
+	wasIncluded=false
+	while read -r line
+	do
+		if [[ "$line" == *"$includeFile"* ]]; then
+			wasIncluded=true
+		else
+			if [[ "$wasIncluded" == false ]]; then
+				echo "$file"
+			fi
+		fi
+	done < <(awk '$1 ~ /^#include/ {print $2}' "$file")
+done < <(find "$directoryToSearch" -type f -name "*.cpp" -o -name "*.cxx" -o -name "*.c++" -o -name "*.c")

--- a/scripts/pch-included-everywhere.zsh
+++ b/scripts/pch-included-everywhere.zsh
@@ -1,0 +1,8 @@
+#!/usr/bin/env zsh
+set -e
+files=$(zsh ./scripts/find-files-without-include.zsh ./src pch.h)
+if ! [ -z $files ]; then
+	echo "Files that don't include pch.h:"
+	echo $files
+	exit 1
+fi


### PR DESCRIPTION
That was made to remind SOMEONE to include the precompiled header.

THE WORKFLOW SHOULD FAIL AND IT IS OK BECAUSE THE PULL REQUEST WAS MADE BEFORE #100 MERGED.