### PR TITLE
Shader: open file read-only

### DIFF
--- a/src/client/graphics/Shader.cpp
+++ b/src/client/graphics/Shader.cpp
@@ -61,7 +61,7 @@ Shader Shader::createShader(const std::string& vertexPath, const std::string& fr
 
 unsigned int Shader::compileShader(const std::string& path, unsigned int type)
 {
-    std::fstream shaderFile;
+    std::ifstream shaderFile;
     std::string shaderCode;
     unsigned int shader = 0;
     const char* sCode = nullptr;


### PR DESCRIPTION
It was failing to open the shader when TRUERPG_RES_DIR_PREFIX was in a
system directory owned by root.