### PR TITLE
ci: Prepare Vulkan SDK

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -24,6 +24,13 @@ jobs:
           sudo apt-get update
           sudo apt-get install xorg-dev libglu1-mesa-dev
 
+      - name: Prepare Vulkan SDK
+        uses: humbletim/setup-vulkan-sdk@v1.2.0
+        with:
+          vulkan-query-version: latest
+          vulkan-components: Vulkan-Headers, Vulkan-Loader, Glslang
+          vulkan-use-cache: true
+
       - name: Configure ccache
         uses: hendrikmuhs/ccache-action@v1.2
         with:
@@ -50,6 +57,13 @@ jobs:
         uses: actions/checkout@v3
         with:
           submodules: recursive
+
+      - name: Prepare Vulkan SDK
+        uses: humbletim/setup-vulkan-sdk@v1.2.0
+        with:
+          vulkan-query-version: latest
+          vulkan-components: Vulkan-Headers, Vulkan-Loader, Glslang
+          vulkan-use-cache: true
         
       - name: Configure CMake
         run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,7 +30,6 @@ target_precompile_headers(${PROJECT_NAME} PRIVATE src/pch.h)
 #endif()
 
 add_subdirectory(libs/glad)
-add_subdirectory(libs/vma)
 
 if(NOT TRUERPG_USE_SYSTEM_GLFW)
   add_subdirectory(libs/glfw)
@@ -40,6 +39,7 @@ endif()
 
 find_package(OpenGL REQUIRED)
 find_package(Vulkan REQUIRED)
+add_subdirectory(libs/vma)
 add_subdirectory(libs/stb_image)
 
 if(NOT TRUERPG_USE_SYSTEM_GLM)

--- a/libs/vma/CMakeLists.txt
+++ b/libs/vma/CMakeLists.txt
@@ -3,3 +3,4 @@ project(vma)
 
 add_library(${PROJECT_NAME} STATIC src/vk_mem_alloc.cpp)
 target_include_directories(${PROJECT_NAME} PUBLIC include/)
+target_link_libraries(${PROJECT_NAME} PUBLIC Vulkan::Vulkan)


### PR DESCRIPTION
It downloads Vulkan headers, Vulkan loader and glslangValidator. It also caches the binaries, so it does not need to redownload them again.